### PR TITLE
use ruby comments instead of html comments

### DIFF
--- a/grammars/ruby haml.cson
+++ b/grammars/ruby haml.cson
@@ -16,7 +16,7 @@
     'captures':
       '1':
         'name': 'punctuation.section.comment.haml'
-    'match': '^ *(/)\\s*\\S.*$\\n?'
+    'match': '^ *(-#)\\s*\\S.*$\\n?'
     'name': 'comment.line.slash.haml'
   }
   {

--- a/scoped-properties/language-haml.cson
+++ b/scoped-properties/language-haml.cson
@@ -1,4 +1,4 @@
 '.text.haml':
   'editor':
-    'commentStart': '/ '
+    'commentStart': '-# '
     'increaseIndentPattern': '^\\s*([-%#\\:\\.\\=].*)\\s*$'


### PR DESCRIPTION
i [prefer](https://github.com/schpet/language-haml/commit/9c4c4dd7d12515771ece6b0cde1a600bbc53ab14) commenting out my code with `-#` instead of `/` because it doesn't render anything (no `<!-- ... -->`) and it doesn't execute any code that nested below it.

this is a pretty lame PR as it breaks syntax highlighting for `/`. syntax highlighting for `-#` _should_ grey out everything nested below that line too. if editing regex in cson files didn't make me want to die i would fix that. that said, i find this more usable than `/`.
