### PR TITLE
Highlight ruby/rails in interpolated strings

### DIFF
--- a/grammars/coffee haml.cson
+++ b/grammars/coffee haml.cson
@@ -131,14 +131,14 @@
     "begin": "#\{",
     "captures": {
       "0": {
-        "name": "punctuation.section.embedded.ruby"
+        "name": "punctuation.section.embedded.coffee"
       }
     },
     "end": "}",
-    "name": "source.ruby.rails.embedded.html",
+    "name": "source.coffee.embedded.html",
     "patterns": [
       {
-        "include": "source.ruby.rails"
+        "include": "source.coffee"
       }
     ]
   }

--- a/grammars/ruby haml.cson
+++ b/grammars/ruby haml.cson
@@ -166,6 +166,21 @@
       }
     ]
   }
+  {
+    "begin": "#\{",
+    "captures": {
+      "0": {
+        "name": "punctuation.section.embedded.ruby"
+      }
+    },
+    "end": "}",
+    "name": "source.ruby.rails.embedded.html",
+    "patterns": [
+      {
+        "include": "source.ruby.rails"
+      }
+    ]
+  }
 ]
 'repository':
   'continuation':


### PR DESCRIPTION
Simply highlight the ruby/rails code inside interpolated strings.
I'm not familiar with these things, so If I'm missing something here, just tell me, I'll try to improve the pull request.
Fix the issue reported there #11.
