### PR TITLE
Disable auto-indent on paste

### DIFF
--- a/scoped-properties/language-haml.cson
+++ b/scoped-properties/language-haml.cson
@@ -1,4 +1,5 @@
 '.text.haml':
   'editor':
+    'autoIndentOnPaste': false
     'commentStart': '-# '
     'increaseIndentPattern': '^([-%#\\:\\.\\=].*)\\s*$'


### PR DESCRIPTION
Auto-indent on paste was added to Atom recently, and is enabled by default. It isn't useful for whitespace-sensitive languages however, so we've disabled it for the whitespace-sensitive languages that we support. Thanks!
