### PR TITLE
Highlight escaped and unescaped ruby code with '!=' and '&=' fixes #23

### DIFF
--- a/grammars/coffee haml.cson
+++ b/grammars/coffee haml.cson
@@ -41,7 +41,7 @@
         'name': 'punctuation.definition.tag.haml'
       '3':
         'name': 'entity.name.tag.haml'
-    'end': '$|(?!\\.|#|\\{|\\[|\\(|=|-|~|/)'
+    'end': '$|(?!\\.|#|\\{|\\[|\\(|=|-|~|!=|&=|/)'
     'patterns': [
       {
         'match': '\\.[\\w-]+'
@@ -106,7 +106,7 @@
     'match': '^\\s*(\\\\.)'
   }
   {
-    'begin': '^\\s*(?==|-|~)'
+    'begin': '^\\s*(?==|-|~|!=|&=)'
     'end': '$'
     'patterns': [
       {
@@ -163,7 +163,7 @@
         'name': 'punctuation.separator.continuation.haml'
     'match': '(\\|,)\\s*\\n'
   'coffeeline':
-    'begin': '=|-|~'
+    'begin': '=|-|~|!=|&='
     'contentName': 'source.coffee.embedded.haml'
     'end': '((do|\\{)( \\|[^|]+\\|)?)$|$|^(?!.*\\|\\s*$)'
     'endCaptures':

--- a/grammars/ruby haml.cson
+++ b/grammars/ruby haml.cson
@@ -41,7 +41,7 @@
         'name': 'punctuation.definition.tag.haml'
       '3':
         'name': 'entity.name.tag.haml'
-    'end': '$|(?!\\.|#|\\{|\\[|\\(|=|-|~|/)'
+    'end': '$|(?!\\.|#|\\{|\\[|\\(|=|-|~|!=|&=|/)'
     'patterns': [
       {
         'match': '\\.[\\w-]+'
@@ -106,7 +106,7 @@
     'match': '^\\s*(\\\\.)'
   }
   {
-    'begin': '^\\s*(?==|-|~)'
+    'begin': '^\\s*(?==|-|~|!=|&=)'
     'end': '$'
     'patterns': [
       {
@@ -228,7 +228,7 @@
         'name': 'punctuation.separator.continuation.haml'
     'match': '(\\||,)\\s*\\n'
   'rubyline':
-    'begin': '=|-|~'
+    'begin': '=|-|~|!=|&='
     'contentName': 'source.ruby.embedded.haml'
     'end': '((do|\\{)( \\|[^|]+\\|)?)$|$|^(?!.*\\|\\s*$)'
     'endCaptures':


### PR DESCRIPTION
Haml supports '!=' and '&=' to start a ruby code line. Highlighting accordingly should be done. Resolves #23  