### PR TITLE
Fix for: incorrect single-line ruby-haml comments.

### DIFF
--- a/grammars/ruby haml.cson
+++ b/grammars/ruby haml.cson
@@ -24,7 +24,7 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.comment.haml'
-    'end': '^(?! *$|\\1 )'
+    'end': '\\n?$'
     'name': 'comment.block.haml'
     'patterns': [
       {


### PR DESCRIPTION
I have no idea what I am doing, but at least it fixes the problem with ruby-haml single-line comments (#37).