### PR TITLE
Fix regex that finds the end of a haml comment

### DIFF
--- a/grammars/ruby haml.cson
+++ b/grammars/ruby haml.cson
@@ -24,7 +24,7 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.comment.haml'
-    'end': '^(?! *$|\\1 )'
+    'end': '\n$'
     'name': 'comment.block.haml'
     'patterns': [
       {


### PR DESCRIPTION
Previous, commenting in a .haml file with `/` or `-#` would italicize and gray out the text on that line, as well as erroneously italicizing and graying out any white text on the following line.

This fix ensures that the end of a comment is determined by a newline character.