### PR TITLE
Fix attribute quoted string highlighting

### DIFF
--- a/grammars/ruby haml.cson
+++ b/grammars/ruby haml.cson
@@ -101,8 +101,18 @@
             'include': '#variables'
           }
           {
-            'begin': '("|\')'
-            'end': '("|\')'
+            'begin': '"'
+            'end': '"'
+            'name': 'string.quoted.double.ruby'
+            'patterns': [
+              {
+                'include': '#interpolated_ruby'
+              }
+            ]
+          }
+          {
+            'begin': '\''
+            'end': '\''
             'name': 'string.quoted.double.ruby'
             'patterns': [
               {


### PR DESCRIPTION
When using the parenthesis syntax instead of curly braces for html attributes, quoted strings highlighting is broken when the string contains quote. For example:

![screen shot 2015-11-11 at 15 05 25](https://cloud.githubusercontent.com/assets/23947/11094083/a8f335d4-8885-11e5-84c1-e2543f3ace50.png)

You can see that the single quote in the placeholder attribute is breaking the highlighting.

Let me know if there is a more elegant way to fix this as I had to duplicate the quoted string rule.
