### PR TITLE
Add keywords for package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.24.0",
   "private": true,
   "description": "HAML package for Atom",
+  "keywords": [
+    "language",
+    "haml"
+  ],
   "repository": "https://github.com/cannikin/language-haml",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Hej!

I'm building a package directory for Atom, which uses the package keywords to categorise them.

These keywords will make the package show up correctly in the Haml category (http://atom-packages.directory/category/languages-haml/)