### PR TITLE
Fix missing interpolation highlighting on GitHub

### DIFF
--- a/grammars/ruby haml.cson
+++ b/grammars/ruby haml.cson
@@ -404,6 +404,25 @@
         }
         # End PHP keywords
         {
+          'begin': '"'
+          'beginCaptures':
+            '0':
+              'name': 'punctuation.definition.string.end.ruby'
+          'end': '"'
+          'endCaptures':
+            '0':
+              'name': 'punctuation.definition.string.end.ruby'
+          'name': 'string.quoted.double.ruby'
+          'patterns': [
+            {
+              'include': 'source.ruby#interpolated_ruby'
+            }
+            {
+              'include': 'source.ruby#escaped_char'
+            }
+          ]
+        }
+        {
           'match': '(\\||,|<|do|\\{)\\s*(\\#.*)?$\\n?'
           'name': 'source.ruby'
           'captures':


### PR DESCRIPTION
This is essentially just duplicating Ruby's string-matching rule so it highlights interpolation correctly on GitHub:

~~~haml
/ HAML comment
- # ruby comment
string
= "string"
= "string" #comment
= "string #{not_comment 2 + 2 + string} string" # comment
~~~

[Output](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgist.github.com%2FAlhadis%2F69755b0281e10e20e675770a3a39ace8%2Fraw%2Fef9199f55564370707f1a501125582aa9808eefd%2Fhaml.cson&grammar_text=&code_source=from-text&code_url=&code=%2F+HAML+comment%0D%0A-+%23+ruby+comment%0D%0Astring%0D%0A%3D+%22string%22%0D%0A%3D+%22string%22+%23comment%0D%0A%3D+%22string+%23%7Bnot_comment+2+%2B+2+%2B+string%7D+string%22+%23+comment%0D%0A):

<img src="https://cloud.githubusercontent.com/assets/2346707/26337573/02e5a366-3fbd-11e7-8f1e-688044629195.png" alt="Figure 1" width="473" />
