### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/grammars/ruby haml.cson
+++ b/grammars/ruby haml.cson
@@ -117,7 +117,7 @@
             'name': 'string.quoted.double.ruby'
             'patterns': [
               {
-                'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
+                'match': '\\\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
                 'name': 'constant.character.escape.ruby'
               }
               {
@@ -131,7 +131,7 @@
             'name': 'string.quoted.double.ruby'
             'patterns': [
               {
-                'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
+                'match': '\\\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
                 'name': 'constant.character.escape.ruby'
               }
               {


### PR DESCRIPTION
Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Atom uses an Oniguruma engine, but github.com relies on a PCRE
engine.