### PR TITLE
Support es6 filter

### DIFF
--- a/grammars/ruby haml.cson
+++ b/grammars/ruby haml.cson
@@ -237,7 +237,7 @@
     ]
   }
   {
-    'begin': '^(\\s*)(:javascript)$'
+    'begin': '^(\\s*)(:(javascript|es6))$'
     'end': '^(?!\\1\\s+|\\n)'
     'name': 'meta.embedded.js'
     'captures':


### PR DESCRIPTION
It's common now to use es6 with babel-transpiler. This highlights those filters correctly.