### PR TITLE
Adds support for if/else statements in haml without the "end"

### DIFF
--- a/snippets/language-haml.cson
+++ b/snippets/language-haml.cson
@@ -153,3 +153,43 @@
   '}, :id => "selector"':
     'prefix': ','
     'body': ', :${1:id} => "${2:selector}"$0'
+'.source.haml':
+  'begin …':
+    'prefix': 'beg'
+    'body': 'begin\n\t${1:condition}\n\t$0'
+  'before …':
+    'prefix': 'bef'
+    'body': 'before(:${1:each}) do\n\t$2'
+  'Benchmark.bmbm do …':
+    'prefix': 'bm'
+    'body': 'TESTS = ${1:10_000}\n- Benchmark.bmbm do |${2:results}|\n\t$3'
+  'case …':
+    'prefix': 'case'
+    'body': 'case ${1:object}\n- when ${2:condition}\n\t$3'
+  'class …':
+    'prefix': 'cla'
+    'body': 'class ${1:ClassName}\n\t$2'
+  'def …':
+    'prefix': 'def'
+    'body': 'def ${1:method_name}\n\t$2'
+  'do …':
+    'prefix': 'do'
+    'body': 'do\n\t${1:condition}$0'
+  'if … else …':
+    'prefix': 'ife'
+    'body': 'if ${1:condition}\n\t$2\n- else\n\t$3'
+  'if …':
+    'prefix': 'if'
+    'body': 'if ${1:condition}\n\t$0'
+  'module …':
+    'prefix': 'mod'
+    'body': 'module ${1:ModuleName}\n\t$2'
+  'unless …':
+    'prefix': 'unless'
+    'body': 'unless ${1:condition}\n\t$2'
+  'until …':
+    'prefix': 'until'
+    'body': 'until ${1:condition}\n\t$2'
+  'while …':
+    'prefix': 'while'
+    'body': 'while ${1:condition}\n\t$2'


### PR DESCRIPTION
This has been bothering me for a while. But not enough to ever cause me to fix the problem. This does fix the problem of over-riding ruby's `if` statements although I'm not positive this is correct way to do it.

@pedantic-git to fix your issue quickly you can open your atom config folder and drop this into `~/.atom/snippets.cson` or just the `~/.atom/packages/language-haml/snippets/language-haml.cson` and when/if this gets merged or updated and merged it'll just over-ride and continue working.

@ezekg let me know if you'd like this fixed or changed?

refs #63 