### PR TITLE
Update ruby haml.cson

### DIFF
--- a/grammars/ruby haml.cson
+++ b/grammars/ruby haml.cson
@@ -81,7 +81,7 @@
       }
       {
         'begin': '(?<!\\#)\\{(?=.+(,|(do)|\\{|\\}|\\||(\\#.*))\\s*)'
-        'end': '\\s*\\}'
+        'end': '\\s*\\}(?!,)'
         'name': 'meta.section.attributes.haml'
         'patterns': [
           {


### PR DESCRIPTION
Update attribute section end to look ahead for the
absence of a comma which would indicate continuation.

Fixes https://github.com/ezekg/language-haml/issues/73