### PR TITLE
link_to snippets updated to fix issue with same prefixes

### DIFF
--- a/snippets/language-haml.cson
+++ b/snippets/language-haml.cson
@@ -87,14 +87,11 @@
     'prefix': 'li'
     'body': '%li ${5:Lorem ipsum...}$0'
   'link_to (route)':
-    'prefix': '='
-    'body': '= link_to "${1:Anchor Text}", ${2:route}_url'
-  'link_to (url)':
-    'prefix': '='
-    'body': '= link_to "${1:Anchor Text}", "${2:#}"'
+    'prefix': 'lt'
+    'body': '= link_to "${1:Anchor Text}", ${2:route}_${3:path}'
   'link_to (wrap selected text)':
     'prefix': '='
-    'body': '= link_to "Anchor text...", ${1:"${2:$0}"}'
+    'body': '= link_to "${1:Anchor Text}", ${2:"${3:$0}"}'
   'ol':
     'prefix': 'ol'
     'body': '%ol${2:{:${3:id} => "${4:selector}"$5\\}}\n\t%li ${6:Lorem ipsum dolor sit amet, consectetur adipisicing elit.}$0'


### PR DESCRIPTION
This also over-rides the `language-ruby-on-rails` package `lt` prefix snippet so that erb tags are not created in haml files

I have removed some of the snippets since the prefix was the same e.g. `=` but kept 1 entry for it for backwards compatibility with upgrades 🎉 

Open to suggestions!

refs #68 